### PR TITLE
Add “VVDEC_ENABLE_SIMD_OPT” CMake Flag 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 # Default top-level .gitignore, please review.
+/amd64Build/
+/arm64Build/
+/downloadBitStreamBuild/
+/ext/
+/x64Build/
 dec.yuv
 rec.yuv
 str.bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Default top-level .gitignore, please review.
 /amd64Build/
 /arm64Build/
+/testBuild/
 /downloadBitStreamBuild/
 /ext/
 /x64Build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ if( NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   return()
 endif()
 
+# enable or disable SIMD optimizations
+set( VVDEC_ENABLE_SIMD_OPT ON CACHE BOOL "Enable or disable SIMD optimizations" )
+
 # enable or disable bitstream download
 set( VVDEC_ENABLE_BITSTREAM_DOWNLOAD OFF CACHE BOOL "Enable or disable bitstream download" )
 
@@ -134,9 +137,14 @@ if( UNIX OR MINGW )
 endif()
 
 # set _WIN32_WINNT
-if( WIN32 )
+if( WIN32 ) 
   # set _WIN32_WINT version global
   add_definitions( -D_WIN32_WINNT=0x0600 )
+endif()
+
+if ( VVDEC_ENABLE_SIMD_OPT )
+  # set USE_SIMD_OPT
+  add_definitions( -DUSE_SIMD_OPT )
 endif()
 
 # enable parallel build for Visual Studio

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Windows sample for Visual Studio 2017 64 Bit:
 
     cd build
     cmake .. -G "Visual Studio 15 2017 Win64"
- or cmake .. -G "Visual Studio 16 2019" -A x64 -D VVDEC_ENABLE_BITSTREAM_DOWNLOAD=1 
- or cmake .. -G "Visual Studio 16 2019" -A arm64 -D VVDEC_ENABLE_SIMD_OPT=0
+    or cmake .. -G "Visual Studio 16 2019" -A x64 -D VVDEC_ENABLE_BITSTREAM_DOWNLOAD=1 
+    or cmake .. -G "Visual Studio 16 2019" -A arm64 -D VVDEC_ENABLE_SIMD_OPT=0
 
 Linux Release Makefile sample:
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Windows sample for Visual Studio 2017 64 Bit:
 
     cd build
     cmake .. -G "Visual Studio 15 2017 Win64"
+ or cmake .. -G "Visual Studio 16 2019" -A x64 -D VVDEC_ENABLE_BITSTREAM_DOWNLOAD=1 
+ or cmake .. -G "Visual Studio 16 2019" -A arm64 -D VVDEC_ENABLE_SIMD_OPT=0
 
 Linux Release Makefile sample:
 

--- a/source/App/vvdecapp/CMakeLists.txt
+++ b/source/App/vvdecapp/CMakeLists.txt
@@ -21,7 +21,7 @@ set_target_properties( ${EXE_NAME} PROPERTIES MINSIZEREL_POSTFIX     "${CMAKE_MI
 
 target_compile_options( ${EXE_NAME} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Werror>
                                             $<$<CXX_COMPILER_ID:GNU>:-Wall -Werror>
-                                            $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX /wd4244 /wd4456 >)
+                                            $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX /wd4244 /wd4456 /wd4819 >)
 target_link_libraries( ${EXE_NAME} Threads::Threads vvdec )
 
 

--- a/source/Lib/CommonLib/Buffer.cpp
+++ b/source/Lib/CommonLib/Buffer.cpp
@@ -55,7 +55,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "Buffer.h"
 #include "InterpolationFilter.h"
 
-#ifndef WIN_ARM64
+#ifdef USE_SIMD_OPT
 #include "CommonDefX86.h"
 #endif
 
@@ -165,7 +165,7 @@ void addWeightedAvgCore( const T* src1, ptrdiff_t src1Stride, const T* src2, ptr
 
 void copyBufferCore( const char *src, ptrdiff_t srcStride, char *dst, ptrdiff_t dstStride, int width, int height )
 {
-#ifndef WIN_ARM64
+#ifdef USE_SIMD_OPT
   _mm_prefetch( (const char *) ( src ),             _MM_HINT_T0 );
   _mm_prefetch( (const char *) ( src + srcStride ), _MM_HINT_T0 );
   _mm_prefetch( (const char *) ( dst ),             _MM_HINT_T0 );
@@ -178,7 +178,7 @@ void copyBufferCore( const char *src, ptrdiff_t srcStride, char *dst, ptrdiff_t 
 
   for( int i = 0; i < height; i++ )
   {
-#ifndef WIN_ARM64
+#ifdef USE_SIMD_OPT
     _mm_prefetch( (const char *) ( src + srcStride ), _MM_HINT_T0 );
     _mm_prefetch( (const char *) ( dst + dstStride ), _MM_HINT_T0 );
 #endif

--- a/source/Lib/CommonLib/Buffer.cpp
+++ b/source/Lib/CommonLib/Buffer.cpp
@@ -55,7 +55,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include "Buffer.h"
 #include "InterpolationFilter.h"
 
+#ifndef WIN_ARM64
 #include "CommonDefX86.h"
+#endif
 
 template< typename T >
 void addAvgCore( const T* src1, ptrdiff_t src1Stride, const T* src2, ptrdiff_t src2Stride, T* dest, ptrdiff_t dstStride, int width, int height, int rshift, int offset, const ClpRng& clpRng )
@@ -163,11 +165,12 @@ void addWeightedAvgCore( const T* src1, ptrdiff_t src1Stride, const T* src2, ptr
 
 void copyBufferCore( const char *src, ptrdiff_t srcStride, char *dst, ptrdiff_t dstStride, int width, int height )
 {
+#ifndef WIN_ARM64
   _mm_prefetch( (const char *) ( src ),             _MM_HINT_T0 );
   _mm_prefetch( (const char *) ( src + srcStride ), _MM_HINT_T0 );
   _mm_prefetch( (const char *) ( dst ),             _MM_HINT_T0 );
   _mm_prefetch( (const char *) ( dst + dstStride ), _MM_HINT_T0 );
-
+#endif
   if( width == srcStride && width == dstStride )
   {
     memcpy( dst, src, width * height );
@@ -175,9 +178,10 @@ void copyBufferCore( const char *src, ptrdiff_t srcStride, char *dst, ptrdiff_t 
 
   for( int i = 0; i < height; i++ )
   {
+#ifndef WIN_ARM64
     _mm_prefetch( (const char *) ( src + srcStride ), _MM_HINT_T0 );
     _mm_prefetch( (const char *) ( dst + dstStride ), _MM_HINT_T0 );
-
+#endif
     memcpy( dst, src, width );
 
     src += srcStride;

--- a/source/Lib/CommonLib/TypeDef.h
+++ b/source/Lib/CommonLib/TypeDef.h
@@ -187,7 +187,11 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 // SIMD optimizations
+#ifndef WIN_ARM64
 #define SIMD_ENABLE                                       1
+#else
+#define SIMD_ENABLE                                       0
+#endif
 #define ENABLE_SIMD_OPT                                 ( SIMD_ENABLE && !RExt__HIGH_BIT_DEPTH_SUPPORT )    ///< SIMD optimizations, no impact on RD performance
 #define ENABLE_SIMD_OPT_MCIF                            ( 1 && ENABLE_SIMD_OPT )                            ///< SIMD optimization for the interpolation filter, no impact on RD performance
 #define ENABLE_SIMD_OPT_BUFFER                          ( 1 && ENABLE_SIMD_OPT )                            ///< SIMD optimization for the buffer operations, no impact on RD performance

--- a/source/Lib/CommonLib/TypeDef.h
+++ b/source/Lib/CommonLib/TypeDef.h
@@ -187,7 +187,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 // SIMD optimizations
-#ifndef WIN_ARM64
+#ifdef USE_SIMD_OPT
 #define SIMD_ENABLE                                       1
 #else
 #define SIMD_ENABLE                                       0

--- a/source/Lib/Utilities/NoMallocThreadPool.cpp
+++ b/source/Lib/Utilities/NoMallocThreadPool.cpp
@@ -51,9 +51,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
 # include <pthread.h>
 #endif
 
-#ifndef WIN_ARM64
+#ifdef USE_SIMD_OPT
 #include <emmintrin.h>
-#endif // !WIN_ARM64
+#endif // USE_SIMD_OPT
 
 
 NoMallocThreadPool::NoMallocThreadPool( int numThreads, const char * threadPoolName )

--- a/source/Lib/Utilities/NoMallocThreadPool.cpp
+++ b/source/Lib/Utilities/NoMallocThreadPool.cpp
@@ -51,7 +51,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
 # include <pthread.h>
 #endif
 
+#ifndef WIN_ARM64
 #include <emmintrin.h>
+#endif // !WIN_ARM64
 
 
 NoMallocThreadPool::NoMallocThreadPool( int numThreads, const char * threadPoolName )

--- a/source/Lib/vvdec/CMakeLists.txt
+++ b/source/Lib/vvdec/CMakeLists.txt
@@ -40,11 +40,19 @@ file( GLOB MD5_INC_FILES "../libmd5/*.h" )
 # get public/extern include files
 file( GLOB PUBLIC_INC_FILES  "../../../include/${LIB_NAME}/*.h" )
 
-# get all source files
-set( SRC_FILES ${BASE_SRC_FILES} ${X86_SRC_FILES} ${SSE41_SRC_FILES} ${SSE42_SRC_FILES} ${AVX_SRC_FILES} ${AVX2_SRC_FILES} ${MD5_SRC_FILES} )
+if (VVDEC_ENABLE_SIMD_OPT)
+  # get all source files
+  set( SRC_FILES ${BASE_SRC_FILES} ${X86_SRC_FILES} ${SSE41_SRC_FILES} ${SSE42_SRC_FILES} ${AVX_SRC_FILES} ${AVX2_SRC_FILES} ${MD5_SRC_FILES} )
+else()
+  set( SRC_FILES ${BASE_SRC_FILES} ${MD5_SRC_FILES} )
+endif()  
 
-# get all include files
-file( GLOB PRIVATE_INC_FILES ${BASE_INC_FILES} ${X86_INC_FILES} ${MD5_INC_FILES}  )
+if (VVDEC_ENABLE_SIMD_OPT)
+  # get all include files
+  file( GLOB PRIVATE_INC_FILES ${BASE_INC_FILES} ${X86_INC_FILES} ${MD5_INC_FILES}  )
+else()
+  file( GLOB PRIVATE_INC_FILES ${BASE_INC_FILES} ${MD5_INC_FILES}  )
+endif()
 
 set( INC_FILES ${PRIVATE_INC_FILES} ${PUBLIC_INC_FILES}  )
 
@@ -59,20 +67,22 @@ endif()
 source_group( "Header Files"          FILES ${PUBLIC_INC_FILES} )
 source_group( "Header Files\\private" FILES ${PRIVATE_INC_FILES} )
 
-# set needed compile definitions
-set_property( SOURCE ${SSE41_SRC_FILES} APPEND PROPERTY COMPILE_DEFINITIONS USE_SSE41 )
-set_property( SOURCE ${SSE42_SRC_FILES} APPEND PROPERTY COMPILE_DEFINITIONS USE_SSE42 )
-set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_DEFINITIONS USE_AVX )
-set_property( SOURCE ${AVX2_SRC_FILES}  APPEND PROPERTY COMPILE_DEFINITIONS USE_AVX2 )
-# set needed compile flags
-if( MSVC )
-  set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_FLAGS "/arch:AVX" )
-  set_property( SOURCE ${AVX2_SRC_FILES}  APPEND PROPERTY COMPILE_FLAGS "/arch:AVX2" )
-elseif( UNIX OR MINGW )
-  set_property( SOURCE ${SSE41_SRC_FILES} APPEND PROPERTY COMPILE_FLAGS "-msse4.1" )
-  set_property( SOURCE ${SSE42_SRC_FILES} APPEND PROPERTY COMPILE_FLAGS "-msse4.2" )
-  set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_FLAGS "-mavx" )
-  set_property( SOURCE ${AVX2_SRC_FILES}  APPEND PROPERTY COMPILE_FLAGS "-mavx2" )
+if (VVDEC_ENABLE_SIMD_OPT)
+  # set needed compile definitions
+  set_property( SOURCE ${SSE41_SRC_FILES} APPEND PROPERTY COMPILE_DEFINITIONS USE_SSE41 )
+  set_property( SOURCE ${SSE42_SRC_FILES} APPEND PROPERTY COMPILE_DEFINITIONS USE_SSE42 )
+  set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_DEFINITIONS USE_AVX )
+  set_property( SOURCE ${AVX2_SRC_FILES}  APPEND PROPERTY COMPILE_DEFINITIONS USE_AVX2 )
+  # set needed compile flags
+  if( MSVC )
+    set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_FLAGS "/arch:AVX" )
+    set_property( SOURCE ${AVX2_SRC_FILES}  APPEND PROPERTY COMPILE_FLAGS "/arch:AVX2" )
+  elseif( UNIX OR MINGW )
+    set_property( SOURCE ${SSE41_SRC_FILES} APPEND PROPERTY COMPILE_FLAGS "-msse4.1" )
+    set_property( SOURCE ${SSE42_SRC_FILES} APPEND PROPERTY COMPILE_FLAGS "-msse4.2" )
+    set_property( SOURCE ${AVX_SRC_FILES}   APPEND PROPERTY COMPILE_FLAGS "-mavx" )
+    set_property( SOURCE ${AVX2_SRC_FILES}  APPEND PROPERTY COMPILE_FLAGS "-mavx2" )
+  endif()
 endif()
 
 # set resource file for MSVC compilers
@@ -87,7 +97,7 @@ target_compile_definitions( ${LIB_NAME} PUBLIC $<$<AND:$<PLATFORM_ID:Windows>,$<
 
 target_compile_options( ${LIB_NAME} PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Werror -Wno-unused-function -Wno-enum-compare-switch -Wno-unknown-attributes>
                                             $<$<CXX_COMPILER_ID:GNU>:-Wall -Werror -Wno-unused-function -Wno-sign-compare -fdiagnostics-show-option>
-                                            $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX /wd4100 /wd4127 /wd4244 /wd4245 /wd4389 /wd4456 /wd4457 /wd4458 /wd4459 /wd4505 /wd4701 /wd4702 /wd4703 >)
+                                            $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX /wd4100 /wd4127 /wd4244 /wd4245 /wd4389 /wd4456 /wd4457 /wd4458 /wd4459 /wd4505 /wd4701 /wd4702 /wd4703 /wd4819 >)
 
 target_include_directories( ${LIB_NAME} PRIVATE           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../include> $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>                                        
                                         SYSTEM INTERFACE  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../include> $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}> )


### PR DESCRIPTION
1、Add “VVDEC_ENABLE_SIMD_OPT” CMake Flag ，default =1；
2、Ignore 4819 warning at compile time when using VS；
3、Improve the command line usage for cmake.